### PR TITLE
Pass optional access key as a header value

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -85,7 +85,9 @@ arguments:
 The `url` is the address of your deployed function app, which can optionally 
 have an `?key=[access-key]` query string with the same value specified in the 
 Function App configuration settings with the name `AccessKey`. If present, it 
-will be used as a shared secret to authorize the SignalR stream connection.
+will be used as a shared secret to authorize the SignalR stream connection. 
+It's passed as the `X-Authorization` custom header and checked by the function 
+during SignalR connection negotiation.
 
 Keep in mind that the built-in EventGrid format for `topic` is rather unwieldy: 
 `/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/topics/{topicName}`. 

--- a/src/FunctionApp/Functions.cs
+++ b/src/FunctionApp/Functions.cs
@@ -56,6 +56,8 @@ public class Functions
             accessKey = req.Query["key"];
         if (StringValues.IsNullOrEmpty(accessKey))
             accessKey = req.Query["k"];
+        if (StringValues.IsNullOrEmpty(accessKey))
+            accessKey = req.Headers["X-Authorization"];
 
         if (StringValues.IsNullOrEmpty(accessKey) ||
             !StringValues.Equals(expectedKey, accessKey))

--- a/src/FunctionApp/local.settings.json
+++ b/src/FunctionApp/local.settings.json
@@ -1,7 +1,6 @@
 {
   "IsEncrypted": false,
   "Values": {
-    "AZURE_FUNCTIONS_ENVIRONMENT": "Development",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "AzureWebJobsStorage": "UseDevelopmentStorage=true"
   }


### PR DESCRIPTION
Adds backwards-compatible check for a new
`X-Authorization` header instead of a query string argument, which is much better. On the CLI and
config, it's still a query string since that's easier to author.

Closes #63